### PR TITLE
Fix runaway emulator subprocess

### DIFF
--- a/src/chisualizer/circuit/ChiselEmulatorSubprocess.py
+++ b/src/chisualizer/circuit/ChiselEmulatorSubprocess.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import string
+import atexit
 
 from Common import Circuit, CircuitNode, CircuitView, TemporalNode
 from ValueDictView import ValueDictView
@@ -38,6 +39,7 @@ class ChiselEmulatorSubprocess(Circuit):
     self.p = subprocess.Popen(emulator_path,
                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT)
+    atexit.register(self.p.terminate)
 
     self.wires = result_to_list(self.command("list_wires"))
     self.mems =  result_to_list(self.command("list_mems"))

--- a/tests/gcd/Makefile
+++ b/tests/gcd/Makefile
@@ -35,7 +35,7 @@ $(PROGFILE): $(OBJ_FILES)
 emulator: $(PROGFILE) 
 
 run: emulator
-	python ../../src/main.py  --emulator emulator/emulator --visualizer_desc gcd.yaml; pkill emulator
+	python ../../src/main.py  --emulator emulator/emulator --visualizer_desc gcd.yaml
 
 clean:
 	rm -rf emulator project target


### PR DESCRIPTION
This commit fixes the issue of the emulator subprocess continuing to run
after the main process exits by adding an exit handler which terminates
the subprocess.
